### PR TITLE
Add .gitignore and tell the compiler to use the C99 standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+smallchat.dSYM
+smallchat

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: smallchat
 
 smallchat: smallchat.c
-	$(CC) smallchat.c -o smallchat -O2 -Wall -W
+	$(CC) smallchat.c -o smallchat -O2 -Wall -W -std=c99
 
 clean:
 	rm -f smallchat


### PR DESCRIPTION
- It is a good idea to have a `.gitignore` file just like any other repo.
- When i firstly try to compile the code, i got some warning said
`warning: GCC does not allow variable declarations in for loop initializers before C99 [-Wgcc-compat]`
so we can use the `-std` option.
