### PR TITLE
Fix realloc potential memory leaks

### DIFF
--- a/smallchat.c
+++ b/smallchat.c
@@ -150,11 +150,12 @@ void *chatMalloc(size_t size) {
 
 /* Also aborting realloc(). */
 void *chatRealloc(void *ptr, size_t size) {
-    ptr = realloc(ptr,size);
-    if (ptr == NULL) {
+    void *new_ptr = realloc(ptr, size); 
+    if (new_ptr == NULL) { 
         perror("Out of memory");
         exit(1);
     }
+    ptr = new_ptr; 
     return ptr;
 }
 


### PR DESCRIPTION
Found realloc assignment to the same expression as passed to the first argument.

The return value of realloc is assigned to the same expression as passed to the first argument. The problem with this construct is that if realloc fails, it returns a null pointer but does not deallocate the original memory. If no other variable is pointing to it, the original memory block is not available anymore for the program to use or free. In either case, p = realloc(p, size) indicates a bad coding style and can be replaced by q = realloc(p, size).

The pointer expression used at realloc can be a variable or a field member of a data structure but cannot contain function calls or unresolved types. In obvious cases when the pointer used at realloc is assigned to another variable before the realloc call, no warning is emitted. This happens only if a simple expression in the form of q = p or void *q = p is found in the same function where p = realloc(p, ...) is found. The assignment has to be before the call to realloc (but otherwise at any place) in the same function. This suppression works only if p is a single variable.