### PR TITLE
fix compile error "storage size of 'hints' isn't know"

### DIFF
--- a/chatlib.c
+++ b/chatlib.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200112L
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>


### PR DESCRIPTION
## bugs description
When i compile it in 'Ubuntu 20.04.1' (The detail information is 'Linux amax 5.4.0-113-generic #127-Ubuntu SMP Wed May 18 14:30:56 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux') with glibc "ldd (Ubuntu GLIBC 2.31-0ubuntu9.9) 2.31". I failed with "storage size of 'hints' isn't know".

I have searched it in the website. I think it might be the "-std=c99" that cause this problem. 

The resolution of this problem in stackoverflow is  
https://stackoverflow.com/questions/37541985/storage-size-of-addrinfo-isnt-known

