### PR TITLE
Ignore up arrow key

### DIFF
--- a/smallchat-client.c
+++ b/smallchat-client.c
@@ -237,6 +237,11 @@ int main(int argc, char **argv) {
             } else if (FD_ISSET(stdin_fd, &readfds)) {
                 /* Data from the user typing on the terminal? */
                 ssize_t count = read(stdin_fd,buf,sizeof(buf));
+                /* Ignore up arrow otherwise horrible things happen. */
+                if(count == 3 && 
+                   buf[0] == 27 && buf[1] == 91 && buf[2] == 65){
+                    continue;
+                }
                 for (int j = 0; j < count; j++) {
                     int res = inputBufferFeedChar(&ib,buf[j]);
                     switch(res) {


### PR DESCRIPTION
Hi there! I created this pull request because I discovered that it's possible to easily alter the logs of smallchat-server or the chat history of smallchat-client using the up arrow key.
In other words, you can easily hack the smallchat-client simply using up arrow key, before doing this if you change you nick by "/nick you", things will be more interesting! :) Lol, just for kidding.
We can simply solve this problem by ignoring the up arrow key, while we reading from stdin. 
![image](https://github.com/antirez/smallchat/assets/28386363/5fa2062d-40f6-4d00-a40a-e558b36a2c57)
![image](https://github.com/antirez/smallchat/assets/28386363/9a238758-9ff6-4a9e-a49e-7b16a78049ae)
